### PR TITLE
snyk-sast: added stats for Snyk scans

### DIFF
--- a/task/sast-snyk-check/0.3/MIGRATION.md
+++ b/task/sast-snyk-check/0.3/MIGRATION.md
@@ -7,6 +7,7 @@ Version 0.3:
 - There are no default arguments as "--all-projects --exclude=test*,vendor,deps" are ignored by Snyk Code
 - SARIF produced by Snyk Code is not included in the CI log.
 - The `KFP_GIT_URL` parameter has been introduced to indicate the repository to filter false positives. If this variable is left empty, the results won't be filtered. At the same time, we can store all excluded findings in a file using the `RECORD_EXCLUDED` parameter and specify a name of project with the `PROJECT_NAME` to use specific filters.
+- The stats of the snyk scan are embedded into the result's SARIF file
 
 ## Action from users
 

--- a/task/sast-snyk-check/0.3/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.3/sast-snyk-check.yaml
@@ -193,7 +193,25 @@ spec:
             (set -x && csgrep --mode=evtstat filtered_sast_snyk_check_out.json)
           fi
 
-          csgrep --mode=sarif filtered_sast_snyk_check_out.json > sast_snyk_check_out.sarif
+          # Generation of scan stats
+
+          total_files=$(jq '[.runs[0].properties.coverage[].files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+          supported_files=$(jq '[.runs[0].properties.coverage[] | select(.type == "SUPPORTED") | .files] | add' "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json)
+
+          # We make sure the values are 0 if no supported/total files are found
+          total_files=${total_files:-0}
+          supported_files=${supported_files:-0}
+
+          coverage_ratio=0
+          if (( total_files > 0 )); then
+              coverage_ratio=$((supported_files * 100 / total_files))
+          fi
+
+          # embed stats in results file and convert to SARIF
+          csgrep --mode=sarif --set-scan-prop snyk-scanned-files-coverage:"${coverage_ratio}" \
+                              --set-scan-prop snyk-scanned-files-success:"${supported_files}"  \
+                              --set-scan-prop snyk-scanned-files-total:"${total_files}" \
+                              filtered_sast_snyk_check_out.json  > sast_snyk_check_out.sarif
 
           TEST_OUTPUT=
           parse_test_output "$(context.task.name)" sarif sast_snyk_check_out.sarif  || true


### PR DESCRIPTION
Solves: https://issues.redhat.com/browse/OSH-769

Adding the stats to snyk scans in the logs traces and as a result of the task.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
