### PR TITLE
sast: added scan stats to coverity

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -144,7 +144,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-### push-dockerfile-oci-ta:0.1 task parameters
+### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
@@ -152,6 +152,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
+### push-dockerfile-oci-ta:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
+|CONTEXT| Path to the directory to use as context.| .| |
+|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| |
+|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| |
+|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
 ### rpms-signature-scan:0.2 task parameters
@@ -162,6 +171,20 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
+### sast-coverity-check:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
+|COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
+|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest to report findings for.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### sast-snyk-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -250,7 +273,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.2:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.2:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.2:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.2:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.2:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.2:SOURCE_ARTIFACT ; coverity-availability-check:0.1:SOURCE_ARTIFACT|
+### push-dockerfile:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -260,6 +287,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
+|TEST_OUTPUT| Tekton task test output.| |
+### sast-coverity-check:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
 ### sast-snyk-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -289,3 +320,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+### push-dockerfile:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
+### sast-coverity-check:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| | False| workspace|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -141,7 +141,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-### push-dockerfile-oci-ta:0.1 task parameters
+### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
@@ -149,6 +149,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
+### push-dockerfile-oci-ta:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
+|CONTEXT| Path to the directory to use as context.| .| |
+|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| |
+|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| |
+|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
 ### rpms-signature-scan:0.2 task parameters
@@ -159,6 +168,20 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
+### sast-coverity-check:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
+|COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
+|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest to report findings for.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### sast-snyk-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -202,9 +225,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| |
+|IMAGE_DIGEST| Digest of the image just built| sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
@@ -247,7 +270,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.2:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.2:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.2:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.2:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.2:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.2:SOURCE_ARTIFACT ; coverity-availability-check:0.1:SOURCE_ARTIFACT|
+### push-dockerfile:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -257,6 +284,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
+|TEST_OUTPUT| Tekton task test output.| |
+### sast-coverity-check:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
 ### sast-snyk-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -286,3 +317,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+### push-dockerfile:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
+### sast-coverity-check:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| | False| workspace|

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -5,13 +5,13 @@
 |---|---|---|---|
 |build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.1:BUILD_ARGS|
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.1:BUILD_ARGS_FILE|
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |event-type| Event that triggered the pipeline run, e.g. push, pull_request| push| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; acs-deploy-check:0.1:gitops-repo-url ; update-deployment:0.1:gitops-repo-url|
 |gitops-auth-secret-name| Secret name to enable this pipeline to update the gitops repo with the new image. | gitops-auth-secret| update-deployment:0.1:gitops-auth-secret-name|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; acs-image-check:0.1:image ; acs-image-scan:0.1:image|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |stackrox-secret| | rox-api-token| acs-image-check:0.1:rox-secret-name ; acs-image-scan:0.1:rox-secret-name ; acs-deploy-check:0.1:rox-secret-name|
@@ -78,6 +78,23 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| |
+### push-dockerfile:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
+|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
+|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
+### rpms-signature-scan:0.2 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
 ### show-sbom-rhdh:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -130,6 +147,16 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+### push-dockerfile:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
+### rpms-signature-scan:0.2 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGES_PROCESSED| Images processed in the task.| |
+|RPMS_DATA| Information about signed and unsigned RPMs| |
+|TEST_OUTPUT| Tekton task test output.| |
 ### show-sbom-rhdh:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -139,7 +166,7 @@
 |name|description|optional|used in tasks
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### acs-deploy-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -155,6 +182,10 @@
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
+### push-dockerfile:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -5,25 +5,18 @@
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 
 ## Available params from tasks
-### apply-tags:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
-|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### build-image-index:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -72,6 +65,37 @@
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+### push-dockerfile:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
+|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
+|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
+### rpms-signature-scan:0.2 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
+### sast-coverity-check:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
+|COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
+|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest to report findings for.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -99,9 +123,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| |
+|IMAGE_DIGEST| Digest of the image just built| push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| apply-tags:0.1:IMAGE|
+|IMAGE_URL| Image repository and tag where the built image was pushed| push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -116,19 +140,33 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+### push-dockerfile:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
+### rpms-signature-scan:0.2 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGES_PROCESSED| Images processed in the task.| |
+|RPMS_DATA| Information about signed and unsigned RPMs| |
+|TEST_OUTPUT| Tekton task test output.| |
+### sast-coverity-check:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|TEST_OUTPUT| Tekton task test output.| |
 ### tkn-bundle:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| |
+|IMAGE_DIGEST| Digest of the image just built| sast-coverity-check:0.1:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed with tag only| build-image-index:0.1:IMAGES|
+|IMAGE_URL| Image repository and tag where the built image was pushed with tag only| build-image-index:0.1:IMAGES ; sast-coverity-check:0.1:image-url|
 
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; sast-coverity-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -142,6 +180,14 @@
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
 |source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
+### push-dockerfile:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
+### sast-coverity-check:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| | False| workspace|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -238,6 +238,45 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
         value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: sast-coverity-check
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values: ["false"]
+        - input: $(tasks.coverity-availability-check.results.STATUS)
+          operator: in
+          values: ["success"]
+      runAfter:
+        - coverity-availability-check
+      taskRef:
+        name: sast-coverity-check
+        version: "0.1"
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      workspaces:
+        - name: workspace
+          workspace: workspace
+    - name: coverity-availability-check
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values: ["false"]
+      runAfter:
+        - build-image-index
+      taskRef:
+        name: coverity-availability-check
+        version: "0.1"
+      params:
+        - name: image-digest
+          value: $(tasks.build-container.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-container.results.IMAGE_URL)
+      workspaces:
+        - name: workspace
+          workspace: workspace
     - name: apply-tags
       runAfter:
         - build-image-index

--- a/task/coverity-availability-check-oci-ta/0.1/README.md
+++ b/task/coverity-availability-check-oci-ta/0.1/README.md
@@ -1,0 +1,18 @@
+# coverity-availability-check-oci-ta task
+
+This task performs needed checks in order to use Coverity image in the pipeline. It will check for a Coverity license secret and an authentication secret for pulling the image.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|AUTH_TOKEN_COVERITY_IMAGE|Name of secret which contains the authentication token for pulling the Coverity image.|auth-token-coverity-image|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COV_LICENSE|Name of secret which contains the Coverity license|cov-license|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+
+## Results
+|name|description|
+|---|---|
+|STATUS|Tekton task simple status to be later checked|
+|TEST_OUTPUT|Tekton task result output.|
+

--- a/task/coverity-availability-check-oci-ta/0.1/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.1/coverity-availability-check-oci-ta.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: coverity-availability-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: This task performs needed checks in order to use Coverity image
+    in the pipeline. It will check for a Coverity license secret and an authentication
+    secret for pulling the image.
+  params:
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token
+        for pulling the Coverity image.
+      default: auth-token-coverity-image
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  results:
+    - name: STATUS
+      description: Tekton task simple status to be later checked
+    - name: TEST_OUTPUT
+      description: Tekton task result output.
+  volumes:
+    - name: auth-token-coverity-image
+      secret:
+        optional: true
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+    - name: cov-license
+      secret:
+        optional: true
+        secretName: $(params.COV_LICENSE)
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: coverity-availability-check
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.7@sha256:cf6808a3bd605630a5d9f20595ff7c43f8645c00381219d32f5a11e88fe37072
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/secrets/cov
+          name: cov-license
+          readOnly: true
+        - mountPath: /etc/secrets/auth/config.json
+          name: auth-token-coverity-image
+          subPath: .dockerconfigjson
+      env:
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: AUTH_TOKEN_COVERITY_IMAGE
+          value: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        # Checking Coverity license
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        if [ -f "${COV_LICENSE_PATH}" ] && [ -s "${COV_LICENSE_PATH}" ]; then
+          echo "Coverity license detected!"
+        else
+          echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
+          echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
+          note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        # Checking authentication token for downloading coverity image
+        AUTH_TOKEN_COVERITY_IMAGE_PATH=/etc/secrets/auth/config.json
+        if [ -f "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ] && [ -s "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ]; then
+          echo "Authentication token detected!"
+        else
+          echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
+          echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
+          note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        note="Task $(context.task.name) completed: Coverity availability checks under /var/workdir/hacbs/$(context.task.name) finished succesfully."
+        # shellcheck disable=SC2034
+        TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+        echo -n "success" | tee "$(results.STATUS.path)"
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"

--- a/task/coverity-availability-check-oci-ta/0.1/recipe.yaml
+++ b/task/coverity-availability-check-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,12 @@
+---
+base: ../../coverity-availability-check/0.1/coverity-availability-check.yaml
+add:
+  - use-source
+  - use-cachi2
+preferStepTemplate: true
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+regexReplacements:
+  hacbs/\$\(context.task.name\): source

--- a/task/coverity-availability-check-oci-ta/OWNERS
+++ b/task/coverity-availability-check-oci-ta/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - integration-team
+reviewers:
+  - integration-team
+  - kdudka

--- a/task/coverity-availability-check/0.1/README.md
+++ b/task/coverity-availability-check/0.1/README.md
@@ -1,0 +1,26 @@
+# coverity-availability-check task
+
+## Description:
+
+This task performs needed checks in order to use Coverity image in the pipeline. It will check for a Coverity license secret and an authentication secret for pulling the image.
+
+The characteristics of these tasks are:
+
+- It will check for a secret called "auth-token-coverity-image" where the authentication token for pulling Coverity image is pulled.
+- It will check for a secret called "cov-license" where the Coverity license is stored.
+
+> NOTE: If any of these tasks fails, the sast-coverity-task check won't be executed. The Coverity license can be used by Red Hat employees only and it needs to be protected such that external users cannot access the license.
+
+## Params:
+
+| name                        | description                                                                            | default value              | required |
+|-----------------------------|----------------------------------------------------------------------------------------|----------------------------|----------|
+| AUTH_TOKEN_COVERITY_IMAGE   | Name of secret which contains the authentication token for pulling the Coverity image  | auth-token-coverity-image  | yes      | 
+| COV_LICENSE                 | Name of secret which contains the Coverity license                                     | cov-license                | yes      |                                                                    
+
+## Results:
+
+| name        | description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| STATUS      | Tekton task simple status to be later checked by the sast-coverity-check task     |
+| TEST_OUTPUT | Tekton task test output.                                                          |

--- a/task/coverity-availability-check/0.1/coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.1/coverity-availability-check.yaml
@@ -1,0 +1,92 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: coverity-availability-check
+spec:
+  description: >-
+    This task performs needed checks in order to use Coverity image in the pipeline. It will check for a Coverity license secret and an authentication secret for pulling the image.
+  results:
+    - description: Tekton task result output.
+      name: TEST_OUTPUT
+    - description: Tekton task simple status to be later checked
+      name: STATUS
+  params:
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token for pulling the Coverity image.
+      default: "auth-token-coverity-image"
+  volumes:
+    - name: cov-license
+      secret:
+        secretName: $(params.COV_LICENSE)
+        optional: true
+    - name: auth-token-coverity-image
+      secret:
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+        optional: true
+  steps:
+    - name: coverity-availability-check
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.7@sha256:cf6808a3bd605630a5d9f20595ff7c43f8645c00381219d32f5a11e88fe37072
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - name: cov-license
+          mountPath: "/etc/secrets/cov"
+          readOnly: true
+        - name: auth-token-coverity-image
+          mountPath: "/etc/secrets/auth/config.json"
+          subPath: .dockerconfigjson
+      env:
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: AUTH_TOKEN_COVERITY_IMAGE
+          value: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        # Checking Coverity license
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        if [ -f "${COV_LICENSE_PATH}" ] && [ -s "${COV_LICENSE_PATH}" ]; then
+          echo "Coverity license detected!"
+        else
+          echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
+          echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
+          note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        # Checking authentication token for downloading coverity image
+        AUTH_TOKEN_COVERITY_IMAGE_PATH=/etc/secrets/auth/config.json
+        if [ -f "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ] && [ -s "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ]; then
+          echo "Authentication token detected!"
+        else
+          echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
+          echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
+          note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        note="Task $(context.task.name) completed: Coverity availability checks under $(workspaces.workspace.path)/hacbs/$(context.task.name) finished succesfully."
+        # shellcheck disable=SC2034
+        TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+        echo -n "success" | tee "$(results.STATUS.path)"
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+  workspaces:
+    - name: workspace

--- a/task/coverity-availability-check/OWNERS
+++ b/task/coverity-availability-check/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - integration-team
+reviewers:
+  - integration-team
+  - kdudka

--- a/task/sast-coverity-check-oci-ta/0.1/README.md
+++ b/task/sast-coverity-check-oci-ta/0.1/README.md
@@ -1,0 +1,26 @@
+# sast-coverity-check-oci-ta task
+
+Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity. At the moment, this task only uses the buildless mode, which does not build the project in order to analyze it.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|AUTH_TOKEN_COVERITY_IMAGE|Name of secret which contains the authentication token for pulling the Coverity image.|auth-token-coverity-image|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COV_ANALYZE_ARGS|Arguments to be appended to the cov-analyze command|--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096|false|
+|COV_LICENSE|Name of secret which contains the Coverity license|cov-license|false|
+|IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|KFP_GIT_URL|URL from repository to download known false positives files|""|false|
+|PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
+|RECORD_EXCLUDED|Write excluded records in file. Useful for auditing (defaults to false).|false|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-digest|Image digest to report findings for.||true|
+|image-url|Image URL.||true|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-coverity-check-oci-ta/0.1/recipe.yaml
+++ b/task/sast-coverity-check-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,12 @@
+---
+base: ../../sast-coverity-check/0.1/sast-coverity-check.yaml
+add:
+  - use-source
+  - use-cachi2
+preferStepTemplate: true
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+regexReplacements:
+  hacbs/\$\(context.task.name\): source

--- a/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
@@ -1,0 +1,297 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sast-coverity-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: Scans source code for security vulnerabilities, including common
+    issues such as SQL injection, cross-site scripting (XSS), and code injection
+    attacks using Coverity. At the moment, this task only uses the buildless
+    mode, which does not build the project in order to analyze it.
+  params:
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token
+        for pulling the Coverity image.
+      default: auth-token-coverity-image
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: COV_ANALYZE_ARGS
+      description: Arguments to be appended to the cov-analyze command
+      type: string
+      default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: IMP_FINDINGS_ONLY
+      description: Report only important findings. Default is true. To report
+        all findings, specify "false"
+      type: string
+      default: "true"
+    - name: KFP_GIT_URL
+      description: URL from repository to download known false positives files
+      type: string
+      default: ""
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+        By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      description: Write excluded records in file. Useful for auditing (defaults
+        to false).
+      type: string
+      default: "false"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-digest
+      description: Image digest to report findings for.
+      type: string
+    - name: image-url
+      description: Image URL.
+      type: string
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: auth-token-coverity-image
+      secret:
+        optional: false
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+    - name: cov-license
+      secret:
+        optional: false
+        secretName: $(params.COV_LICENSE)
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: sast-coverity-check
+      image: quay.io/redhat-services-prod/sast/coverity@sha256:0d1b96fb08a901b2d0e340599c7fee7e1de25e2d6ba58f3d95db4983f32b5a3c
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/secrets/cov
+          name: cov-license
+          readOnly: true
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: IMP_FINDINGS_ONLY
+          value: $(params.IMP_FINDINGS_ONLY)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /usr/local/share/konflux-test/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        echo 'Starting Coverity buildless scan'
+
+        export HOME="/var/tmp/coverity/home"
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        COVERITY_DIR=/var/tmp/coverity/idir
+        COVERITY_RESULTS_FILE=/var/workdir/coverity-buildless-results.json
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        SOURCE_CODE_DIR=/var/workdir
+
+        # Installing Coverity license
+        cp "$COV_LICENSE_PATH" /opt/coverity/bin/license.dat
+
+        # Installation of Red Hat certificates for cloning Red Hat internal repositories
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Create configuration file for coverity buildless
+        echo -e 'capture:\n   build-command-inference: false' >"$SOURCE_CODE_DIR"/coverity.yml
+
+        set +e -x
+        # Buildless scan
+        # shellcheck disable=SC2086
+        env COV_HOST=konflux /opt/coverity/bin/coverity capture --project-dir "$SOURCE_CODE_DIR" --dir "$COVERITY_DIR"
+        COV_CAPTURE_EXIT_CODE=$?
+        set -x
+
+        if [[ "$COV_CAPTURE_EXIT_CODE" -eq 0 ]]; then
+          echo "Coverity capture scan finished successfully"
+        else
+          echo "Coverity capture command failed with exit code ${COV_CAPTURE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+
+        # Analysis phase
+        set -x
+        /opt/coverity/bin/cov-manage-emit --dir $COVERITY_DIR reset-host-name
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir="$COVERITY_DIR"
+        COV_ANALYZE_EXIT_CODE=$?
+        set +x
+
+        if [[ "$COV_ANALYZE_EXIT_CODE" -eq 0 ]]; then
+          echo "cov-analyze scan finished successfully"
+        else
+          echo "cov-analyze scan failed with exit code ${COV_ANALYZE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+        set -e
+
+        /opt/coverity/bin/cov-format-errors --dir="$COVERITY_DIR" --json-output-v10 "$COVERITY_RESULTS_FILE"
+        # We parse the results, embed context, remove duplicates and store them in SARIF format.
+        IMP_LEVEL=1
+        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+          IMP_LEVEL=0
+        fi
+
+        (cd "$SOURCE_CODE_DIR" && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --embed-context=3 "$COVERITY_RESULTS_FILE") |
+          csgrep --mode=json --strip-path-prefix="$SOURCE_CODE_DIR"/source/ |
+          csgrep --mode=json --strip-path-prefix="$HOME" \
+            >sast_coverity_buildless_check_all_findings.json
+
+        echo "Results:"
+        (set -x && csgrep --mode=evtstat sast_coverity_buildless_check_all_findings.json)
+
+        # We check if the KFP_GIT_URL variable is set to apply the filters or not
+        if [[ -z "${KFP_GIT_URL}" ]]; then
+          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+          mv sast_coverity_buildless_check_all_findings.json filtered_sast_coverity_buildless_check_all_findings.json
+        else
+          echo "Filtering false positives in results files using csfilter-kfp..."
+          CMD=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+            --project-nvr="${PROJECT_NAME}"
+          )
+
+          if [ "${RECORD_EXCLUDED}" == "true" ]; then
+            CMD+=(--record-excluded="excluded-findings.json")
+          fi
+
+          "${CMD[@]}" sast_coverity_buildless_check_all_findings.json >filtered_sast_coverity_buildless_check_all_findings.json
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "Error: failed to filter known false positives" >&2
+            return 1
+          else
+            echo "Message: Succeed to filter known false positives" >&2
+          fi
+
+          echo "Results after filtering:"
+          (set -x $$ csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
+        fi
+
+        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json >"/var/workdir"/coverity-results.sarif
+
+        if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif "/var/workdir"/coverity-results.sarif || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      computeResources:
+        limits:
+          cpu: "16"
+          memory: 32Gi
+        requests:
+          cpu: "8"
+          memory: 16Gi
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
+      workingDir: /var/workdir
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ] || [ -z "${IMAGE_DIGEST}" ]; then
+          echo 'No image-url or image-digest param provided. Skipping upload.'
+          exit 0
+        fi
+        UPLOAD_FILES="coverity-results.sarif excluded-findings.json"
+
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done

--- a/task/sast-coverity-check-oci-ta/OWNERS
+++ b/task/sast-coverity-check-oci-ta/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - integration-team
+reviewers:
+  - integration-team
+  - kdudka

--- a/task/sast-coverity-check/0.1/README.md
+++ b/task/sast-coverity-check/0.1/README.md
@@ -1,0 +1,45 @@
+# sast-coverity-check task
+
+## Description:
+
+The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST). In this task, we use the buildless mode, where Coverity has the ability to capture source code without the need of building the product.
+
+The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+
+The characteristics of these tasks are:
+
+- Perform buildless scanning with Coverity
+- The whole source code is scanned (by scanning `$(workspaces.source.path)` )
+- Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
+- The csdiff/v1 SARIF fingerprints are provided for all findings
+- A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
+
+> NOTE: This task is executed only if there is a Coverity license set up in the environment. Please check coverity-availability-check task for more information.
+
+## Params:
+
+| name                      | description                                                                                                                           | default value             | required |                                                                                                                   
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------|
+| COV_ANALYZE_ARGS          | Append arguments to the cov-analyze CLI command                                                                                       | ""                        | no       |
+| COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
+| AUTH_TOKEN_COVERITY_IMAGE | Name of secret which contains the authentication token for pulling the Coverity image                                                 | auth-token-coverity-image | no       |
+| IMP_FINDINGS_ONLY         | Report only important findings. Default is true. To report all findings, specify "false"                                              | true                      | no       |
+| KFP_GIT_URL               | Known False Positives git URL, optionally taking a revision delimited by #; If empty, filtering of known false positives is disabled. | ""                        | no       |
+| PROJECT_NAME              | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                       | ""                        | no       |
+| RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
+
+## Results:
+
+| name              | description              |
+|-------------------|--------------------------|
+| TEST_OUTPUT       | Tekton task test output. |
+
+## Source repository for image:
+
+// TODO: Add reference to private repo for the container image once the task is migrated to repo
+
+
+## Additional links:
+
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/cli/topics/options_reference.html

--- a/task/sast-coverity-check/0.1/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.1/sast-coverity-check.yaml
@@ -1,0 +1,301 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: sast-coverity-check
+spec:
+  description: >-
+    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity. At the moment, this task only uses the buildless mode, which does not build the project in order to analyze it.
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+  params:
+    - description: Image URL.
+      name: image-url
+      type: string
+    - description: Image digest to report findings for.
+      name: image-digest
+      type: string
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+    - description: Arguments to be appended to the cov-analyze command
+      name: COV_ANALYZE_ARGS
+      type: string
+      default: "--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096"
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token for pulling the Coverity image.
+      default: "auth-token-coverity-image"
+    - name: IMP_FINDINGS_ONLY
+      type: string
+      description: Report only important findings. Default is true. To report all findings, specify "false"
+      default: "true"
+    - name: KFP_GIT_URL
+      type: string
+      description: URL from repository to download known false positives files
+      # FIXME: Red Hat internal projects will default to https://gitlab.cee.redhat.com/osh/known-false-positives.git when KONFLUX-4530 is resolved
+      default: ""
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+            By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      description: Write excluded records in file. Useful for auditing (defaults to false).
+      default: "false"
+  volumes:
+    - name: cov-license
+      secret:
+        secretName: $(params.COV_LICENSE)
+        optional: false
+    - name: auth-token-coverity-image
+      secret:
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+        optional: false
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  steps:
+    - name: sast-coverity-check
+      # image: $(steps.secrets-check.results.image)
+      image: quay.io/redhat-services-prod/sast/coverity@sha256:0d1b96fb08a901b2d0e340599c7fee7e1de25e2d6ba58f3d95db4983f32b5a3c
+      computeResources:
+        requests:
+          memory: "16Gi"
+          cpu: "8"
+        limits:
+          memory: "32Gi"
+          cpu: "16"
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - name: cov-license
+          mountPath: "/etc/secrets/cov"
+          readOnly: true
+        - name: trusted-ca
+          mountPath: /mnt/trusted-ca
+          readOnly: true
+      env:
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: IMP_FINDINGS_ONLY
+          value: $(params.IMP_FINDINGS_ONLY)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /usr/local/share/konflux-test/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        echo 'Starting Coverity buildless scan'
+
+        export HOME="/var/tmp/coverity/home"
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        COVERITY_DIR=/var/tmp/coverity/idir
+        COVERITY_RESULTS_FILE=$(workspaces.workspace.path)/coverity-buildless-results.json
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+
+        # Installing Coverity license
+        cp "$COV_LICENSE_PATH" /opt/coverity/bin/license.dat
+
+        # Installation of Red Hat certificates for cloning Red Hat internal repositories
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Create configuration file for coverity buildless
+        echo -e 'capture:\n   build-command-inference: false' > "$SOURCE_CODE_DIR"/coverity.yml
+
+        set +e -x
+        # Buildless scan
+        # shellcheck disable=SC2086
+        env COV_HOST=konflux /opt/coverity/bin/coverity capture --project-dir "$SOURCE_CODE_DIR" --dir "$COVERITY_DIR"
+        COV_CAPTURE_EXIT_CODE=$?
+        set -x
+
+        if [[ "$COV_CAPTURE_EXIT_CODE" -eq 0 ]]; then
+          echo "Coverity capture scan finished successfully"
+        else
+          echo "Coverity capture command failed with exit code ${COV_CAPTURE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+
+        # Analysis phase
+        set -x
+        /opt/coverity/bin/cov-manage-emit --dir $COVERITY_DIR reset-host-name
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir="$COVERITY_DIR"
+        COV_ANALYZE_EXIT_CODE=$?
+        set +x
+
+        if [[ "$COV_ANALYZE_EXIT_CODE" -eq 0 ]]; then
+          echo "cov-analyze scan finished successfully"
+        else
+          echo "cov-analyze scan failed with exit code ${COV_ANALYZE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+        set -e
+
+        /opt/coverity/bin/cov-format-errors --dir="$COVERITY_DIR" --json-output-v10 "$COVERITY_RESULTS_FILE"
+        # We parse the results, embed context, remove duplicates and store them in SARIF format.
+        IMP_LEVEL=1
+        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+          IMP_LEVEL=0
+        fi
+
+        (cd "$SOURCE_CODE_DIR" && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --embed-context=3 "$COVERITY_RESULTS_FILE") \
+        | csgrep --mode=json --strip-path-prefix="$SOURCE_CODE_DIR"/source/ \
+        | csgrep --mode=json --strip-path-prefix="$HOME" \
+        > sast_coverity_buildless_check_all_findings.json
+
+        echo "Results:"
+        (set -x && csgrep --mode=evtstat sast_coverity_buildless_check_all_findings.json)
+
+        # We check if the KFP_GIT_URL variable is set to apply the filters or not
+        if [[ -z "${KFP_GIT_URL}" ]]; then
+          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+          mv sast_coverity_buildless_check_all_findings.json filtered_sast_coverity_buildless_check_all_findings.json
+        else
+          echo "Filtering false positives in results files using csfilter-kfp..."
+          CMD=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+            --project-nvr="${PROJECT_NAME}"
+          )
+
+          if [ "${RECORD_EXCLUDED}" == "true" ]; then
+            CMD+=(--record-excluded="excluded-findings.json")
+          fi
+
+          "${CMD[@]}" sast_coverity_buildless_check_all_findings.json > filtered_sast_coverity_buildless_check_all_findings.json
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "Error: failed to filter known false positives" >&2
+            return 1
+          else
+            echo "Message: Succeed to filter known false positives" >&2
+          fi
+
+          echo "Results after filtering:"
+          (set -x $$ csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
+        fi
+        
+        # Generation of stats
+        /opt/coverity/bin/coverity list --dir "$COVERITY_DIR" > coverity_list_command.txt
+
+        # Parse the summary statistics using grep
+        SUCCEEDED=$(grep "SUCCEEDED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        INCOMPLETE=$(grep "INCOMPLETE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        FAILED=$(grep "FAILED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        IGNORED=$(grep "IGNORED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        FILES_CAPTURED=$(grep "FILES CAPTURED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        LINES_OF_CODE=$(grep "LINES OF CODE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+
+        # Calculate the total number of files
+        TOTAL_FILES=$((SUCCEEDED + INCOMPLETE + FAILED + IGNORED))
+
+        # Calculate the ratio of successful files to total files
+        if [ "$TOTAL_FILES" -ne 0 ]; then
+            COVERAGE_RATIO=$((SUCCEEDED * 100 / TOTAL_FILES))
+        else
+            COVERAGE_RATIO="0"
+        fi
+
+        csgrep --mode=sarif --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}" \
+        filtered_sast_coverity_buildless_check_all_findings.json \
+        > "$(workspaces.workspace.path)"/coverity-results.sarif
+
+        if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif "$(workspaces.workspace.path)"/coverity-results.sarif || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
+      workingDir: $(workspaces.workspace.path)
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ] || [ -z "${IMAGE_DIGEST}" ]; then
+          echo 'No image-url or image-digest param provided. Skipping upload.'
+          exit 0
+        fi
+        UPLOAD_FILES="coverity-results.sarif excluded-findings.json"
+
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done
+  workspaces:
+    - name: workspace

--- a/task/sast-coverity-check/OWNERS
+++ b/task/sast-coverity-check/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - integration-team
+reviewers:
+  - integration-team
+  - kdudka


### PR DESCRIPTION
Solves: https://issues.redhat.com/browse/OSH-769

Added stats to SARIF result file by using the coverity list command.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
